### PR TITLE
✅Correct extension name

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -21,7 +21,7 @@ Then, add the extension name to ``extensions`` configuration item in your conf.p
 
    extensions = [
              # …
-             'sphinxnotes-strike',
+             'sphinxnotes.strike',
              # …
              ]
 


### PR DESCRIPTION
This project's directories had been restructured, use `sphinxnotes.strike` instead of ~~sphinxnotes_strike~~